### PR TITLE
Use friendlier subject instead of name

### DIFF
--- a/recollect_waste/__init__.py
+++ b/recollect_waste/__init__.py
@@ -61,8 +61,11 @@ class RecollectWasteClient():
 
                 for flag in event['flags']:
                     # We only want pickup event types
-                    if flag['event_type'] == 'pickup':
-                        pickup_event.pickup_types.append(flag['subject'])
+                    if 'event_type' in flag and flag['event_type'] == 'pickup':
+                        if 'subject' in flag:
+                            pickup_event.pickup_types.append(flag['subject'])
+                        elif 'name' in flag:
+                            pickup_event.pickup_types.append(flag['name'])
                         pickup_event.area_name = flag['area_name']
 
             return pickup_events

--- a/recollect_waste/__init__.py
+++ b/recollect_waste/__init__.py
@@ -62,7 +62,7 @@ class RecollectWasteClient():
                 for flag in event['flags']:
                     # We only want pickup event types
                     if flag['event_type'] == 'pickup':
-                        pickup_event.pickup_types.append(flag['name'])
+                        pickup_event.pickup_types.append(flag['subject'])
                         pickup_event.area_name = flag['area_name']
 
             return pickup_events


### PR DESCRIPTION
For my area, certain events have somewhat clunky names, but more useful subjects (city names redacted):

| name | subject |
|---|---|
| Garbage | Garbage |
| MixedRecycle | Mixed recycling |
| GlassRecycle | Glass recycling |
| XXXXXXXXXXX_FoodYardDebris | Food and yard debris |
| leafXXXXXXXXX | Free Leaf Drop-off Event |
| rx | National Rx Drug Take Back Day |
| shredXXXXX | XXXXXXXXX free document shred event |

Populate pickup_types with those friendlier names instead, when available.